### PR TITLE
A blank target URL here would be nice.

### DIFF
--- a/_guide/02_setup.md
+++ b/_guide/02_setup.md
@@ -14,7 +14,7 @@ times.
 
 To do this, take the following steps:
 
-* Go to [https://github.com/new/import](https://github.com/new/import).
+* Go to <a href="https://github.com/new/import" target="_blank">https://github.com/new/import</a>
 * Enter the URL of the `textbooks-with-jupyter` repository in the
   "old repository's clone URL" field:
 


### PR DESCRIPTION
That way you still have the original page left in another tab, when you go to the linked page. 

Also, this link is not currently rendered as a link on [this page](http://predictablynoisy.com/textbooks-with-jupyter/guide/02_setup/#get-your-own-copy-of-this-repository), in my experience.